### PR TITLE
fixed end of line \ fold highlighting of next word

### DIFF
--- a/grammars/livescript-edge.cson
+++ b/grammars/livescript-edge.cson
@@ -525,7 +525,7 @@ repository:
   backslash_string:
     patterns: [
       {
-        begin: "\\\\([\\\\)\\s,\\};\\]])?"
+        begin: "\\\\([\\\\)\\s,\\};\\]])?(?!$)"
         beginCaptures:
           "0":
             name: "string.quoted.single.livescript"


### PR DESCRIPTION
this fixes:

``` LiveScript
var something, something, something,\
    somethingelse, something
```

`somethingelse` will be highlighted wrong as the `\` will initiate the `\word` even if the end of line occurs
